### PR TITLE
Consistently represent dbg

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,12 +100,12 @@ It's based on [Burghard's WSA](https://github.com/wspace/burghard-wsa) as assemb
 
 While on debug mode, this interpreter adds some language extensions to debug or increase performance. For this, a few more operations are added, both to the assembler and the whitespace code ops:
 
-- `debugger`: "LLS" Signals the interpreter to pause execution at that point.
+- `dbg`: "LLS" Signals the interpreter to pause execution at that point.
 - `and`: "TSLL" Performs the bitwise and operation of the top 2 values of the stack.
 - `or`: "TSLS" Performs the bitwise or operation of the top 2 values of the stack.
 - `not`: "TSLT" Performs the bitwise not operation to the top value of the stack.
 
-As these are not whitespace standard, the assembler will omit the `debugger` instruction if the extension is not enabled, and throw an Error for the bitwise operations.
+As these are not whitespace standard, the assembler will omit the `dbg` instruction if the extension is not enabled, and throw an Error for the bitwise operations.
 
 ## STD lib
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ While on debug mode, this interpreter adds some language extensions to debug or 
 - `or`: "TSLS" Performs the bitwise or operation of the top 2 values of the stack.
 - `not`: "TSLT" Performs the bitwise not operation to the top value of the stack.
 
-As these are not whitespace standard, the assembler will omit the `dbg` instruction if the extension is not enabled, and throw an Error for the bitwise operations.
+As these are not whitespace standard, if the `--extensions` option is not enabled, the assembler will omit the `dbg` instruction and throw an Error for the bitwise operations.
 
 ## STD lib
 

--- a/src/app/ProgramLoader.tsx
+++ b/src/app/ProgramLoader.tsx
@@ -3,7 +3,7 @@ import { Button } from "../lib";
 import { WhitespaceOp, parseWhitespaceProgram } from "../whitespace";
 import {
   compileAndExit,
-  enableDebugExtensions,
+  enableExtensions,
   stringToLineStream,
 } from "../wsa/wsa";
 
@@ -14,7 +14,7 @@ export const ProgramLoader: FC<{
 
   const loadASM = async () => {
     const stringValue = ref.current!.value;
-    enableDebugExtensions();
+    enableExtensions();
 
     if (stringValue.includes("[LF]")) {
       onSubmit(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,5 @@
 import { Command } from "@commander-js/extra-typings";
-import { LineStream, compileAndExit, enableDebugExtensions } from "./wsa/wsa";
+import { LineStream, compileAndExit, enableExtensions } from "./wsa/wsa";
 import readline from "readline";
 import fs from "node:fs";
 import { writeFile, readFile } from "node:fs/promises";
@@ -16,10 +16,10 @@ program
   .description("Compile assembly file into whitespace")
   .argument("<main>", "entry point file to compile")
   .argument("<output>", "output file to store the result")
-  .option("--debugger", "include debugger symbols")
+  .option("--extensions", "use extension instructions")
   .action(async (main, output, options) => {
-    if (options.debugger) {
-      enableDebugExtensions();
+    if (options.extensions) {
+      enableExtensions();
     }
 
     const result = await compileAndExit(

--- a/src/wsa/wsa.ts
+++ b/src/wsa/wsa.ts
@@ -193,9 +193,8 @@ function store(value?: bigint) {
 }
 function storestr(value: string) {
   return (
-    (value + "\0")
-      .split("")
-      .map((v) => dup() + push(BigInt(v.charCodeAt(0))) + store() + add(1n))
+    [...value + "\0"]
+      .map((v) => dup() + push(BigInt(v.codePointAt(0)!)) + store() + add(1n))
       .join("") + pop()
   );
 }

--- a/src/wsa/wsa.ts
+++ b/src/wsa/wsa.ts
@@ -165,19 +165,19 @@ function mod(value?: bigint) {
   return pushIfDefined(value) + "\t \t\t";
 }
 function and(value?: bigint) {
-  if (!debugExtensions) {
+  if (!extensions) {
     throw new Error("Can't use `and`: Extensions not enabled");
   }
   return pushIfDefined(value) + `\t \n\n`;
 }
 function or(value?: bigint) {
-  if (!debugExtensions) {
+  if (!extensions) {
     throw new Error("Can't use `or`: Extensions not enabled");
   }
   return pushIfDefined(value) + `\t \n `;
 }
 function not() {
-  if (!debugExtensions) {
+  if (!extensions) {
     throw new Error("Can't use `not`: Extensions not enabled");
   }
   return `\t \n\t`;
@@ -246,7 +246,7 @@ async function include(
   if (filename === "bitwise") {
     return compile(
       stringToLineStream(
-        debugExtensions ? lib_bitwise_extensions : lib_bitwise
+        extensions ? lib_bitwise_extensions : lib_bitwise
       ),
       getIncludedStream
     );
@@ -283,12 +283,12 @@ function valueinteger(name: string, value: bigint) {
   return "";
 }
 
-let debugExtensions = false;
-export function enableDebugExtensions() {
-  debugExtensions = true;
+let extensions = false;
+export function enableExtensions() {
+  extensions = true;
 }
 function dbg() {
-  return debugExtensions ? "\n\n " : "";
+  return extensions ? "\n\n " : "";
 }
 
 type Token = WordToken | IntegerToken | StringToken | CharToken | VariableToken | DecorationToken;

--- a/src/wsa/wsa.ts
+++ b/src/wsa/wsa.ts
@@ -50,7 +50,7 @@ const opcodes: { [key: string]: Opcode } = {
   readc: { constr: readc, params: "none" },
   valuestring: { constr: valuestring, params: "variable,string" },
   valueinteger: { constr: valueinteger, params: "variable,integer" },
-  debugger: { constr: _debugger, params: "none" },
+  dbg: { constr: dbg, params: "none" },
 };
 
 export type LineStream = (onLine: (line: string | null) => void) => () => void;
@@ -287,7 +287,7 @@ let debugExtensions = false;
 export function enableDebugExtensions() {
   debugExtensions = true;
 }
-function _debugger() {
+function dbg() {
   return debugExtensions ? "\n\n " : "";
 }
 

--- a/wsa-tests/count.wsa
+++ b/wsa-tests/count.wsa
@@ -4,7 +4,8 @@ dup
 outn
 add 1
 dup
-test 10
+push 10
+sub
 jumpz end
 push ' '
 outc

--- a/wsa-tests/regress/ignored_arguments.wsa
+++ b/wsa-tests/regress/ignored_arguments.wsa
@@ -11,4 +11,4 @@ outn 1
 outc 1
 readn 1
 readc 1
-debugger 1
+dbg 1


### PR DESCRIPTION
This makes the `dbg` instruction more consistent. The assembler recognized it as both `debugger`, but it was `dbg` elsewhere, and the Whitespace parser recognized it as both `"\n\n "` and `"\n\n\t"`, but the assembler always emitted `"\n\n "`. Standardize on `dbg` and `"\n\n "`.

Also rename the `--debugger` option to `--extensions` to reflect its broader purpose and fix a broken test.

See the commit messages for more details.

I'm revisiting my universal assembler, so these fixes came to mind. You may be interested in seeing my [list of extension instructions](https://github.com/thaliaarchi/notes/blob/main/wspace/semantics/extensions.md) from various Whitespace implementations, including yours.